### PR TITLE
Added basic rules for automatic indentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,31 @@
+WM NuSMV
+========
+
+Summary
+-------
+
+Vim plugin for [NuSMV](http://nusmv.irst.itc.it/).
+
+Features
+--------
+
+* Syntax coloring
+* Omnicompletion
+* Basic indentation rules
+* ...
+
+Settings
+--------
+
+* ...
+
+Dependencies
+------------
+
+* [NuSMV](http://nusmv.irst.itc.it/)
+
+Contact
+-------
+
+Wannes Meert, wannes.meert@cs.kuleuven.be
+

--- a/doc/wmnusmv.txt
+++ b/doc/wmnusmv.txt
@@ -1,0 +1,31 @@
+*wmnusmv.txt* Plugin + syntax for NuSMV
+*WMNuSMV*
+
+This plugin provides the following features for NuSMV:
+- Syntax highlighting
+- Omnicompletion
+
+
+|wmnusmv-requirements|		REQUIREMENTS
+|wmnusmv-omnicompletion|	OMNICOMPLETION
+
+
+REQUIREMENTS                                           *wmnusvm-requirements*
+
+This plugin expects NuSMV (http://nusmv.irst.itc.it/) to be installed in the
+path.
+
+
+OMNICOMPLETION                                         *wmnusmv-omnicompletion*
+
+The plugin supports Vim omnicompletion (<C-X><C-O>) for keywords.
+
+
+CONTACT                                                        *wmnusmv-contact*
+
+Plugin by Wannes Meert, mailto:wannes.meert@cs.kuleuven.be, 2010.
+
+
+vim:tw=78:ts=8:sw=8:ft=help:norl:noet:
+
+

--- a/ftdetect/nusmv.vim
+++ b/ftdetect/nusmv.vim
@@ -1,0 +1,2 @@
+au BufRead,BufNewFile *.smv setlocal filetype=nusmv
+

--- a/ftplugin/nusmv.vim
+++ b/ftplugin/nusmv.vim
@@ -1,0 +1,21 @@
+" WMNuSMV.vim plugin
+" Author:  Wannes Meert
+" Email:   wannes.meert@cs.kuleuven.be
+" Version: 0.1
+
+if exists('s:loaded')
+	finish
+endif
+let s:loaded = 1
+
+" ...
+
+" Comments
+set commentstring=--%s
+
+" Cmd-B
+"unmap <D-b>
+"map <D-b> :!NuSMV %
+setl makeprg=NuSMV\ %
+setl errorformat=file\ %f:\ line\ %l:\ %m
+

--- a/indent/nusmv.vim
+++ b/indent/nusmv.vim
@@ -1,0 +1,64 @@
+if exists('b:did_indent') | finish | endif
+let b:did_indent = 1
+
+setlocal nolisp
+setlocal autoindent
+
+setlocal indentexpr=NusmvIndent(v:lnum)
+setlocal indentkeys+=;,=case,=esac,=VAR,=ASSIGN,=FAIRNESS,=TRANS,=INIT,=DEFINE,=CONSTANTS,=IVAR,=INVAR,=SPEC,=CTLSPEC,=LTLSPEC,=PSLSPEC,=COMPUTE,=INVARSPEC,=JUSTICE,=COMPASSION,=ISA,=CONSTRAINT,=SIMPWFF,=CTLWFF,=LTLWFF,=PSLWFF,=COMPWFF,=FROZENVAR
+
+if exists("*NusmvIndent") | finish | endif
+
+function s:startsModule(line)
+    return a:line =~# '^\s*MODULE '
+endfunction
+
+function s:hasSectionKeyword(line)
+    return a:line =~# '\<\(VAR\|ASSIGN\|FAIRNESS\|TRANS\|INIT\|DEFINE\|CONSTANTS\|IVAR\|INVAR\|SPEC\|CTLSPEC\|LTLSPEC\|PSLSPEC\|COMPUTE\|INVARSPEC\|JUSTICE\|COMPASSION\|ISA\|CONSTRAINT\|SIMPWFF\|CTLWFF\|LTLWFF\|PSLWFF\|COMPWFF\|FROZENVAR\)\>'
+endfunction
+
+function s:getPreviousNotEmptyLineNr(lnum)
+    let lnum = a:lnum - 1
+    while lnum > 0
+        if !(getline(lnum) =~ '^\s*$')
+            return lnum
+        endif
+        let lnum = lnum - 1
+    endwhile
+    return 0
+endfunction
+
+function s:hasCaseKeyword(line)
+    return a:line =~# '\<case\>'
+endfunction
+
+function s:isCaseEsacStatement(line)
+    return a:line =~# '^.*\:[^=-\:].*;'
+endfunction
+
+function NusmvIndent(lnum)
+    let curr_line = getline(a:lnum)
+    if s:startsModule(curr_line)
+        return 0
+    endif
+    if s:hasSectionKeyword(curr_line)
+        return 0
+    endif
+
+    let prev_line_nr = s:getPreviousNotEmptyLineNr(a:lnum)
+    let prev_line = getline(prev_line_nr)
+    if prev_line != ''
+        let i = indent(prev_line_nr)
+        if s:hasSectionKeyword(prev_line)
+            return i + 4
+        endif
+        if s:hasCaseKeyword(prev_line) && s:isCaseEsacStatement(curr_line)
+            let i += 4
+        endif
+        if s:isCaseEsacStatement(prev_line) && !s:isCaseEsacStatement(curr_line)
+            let i -= 4
+        endif
+        return i
+    endif
+    return -1
+endfunction

--- a/syntax/nusmv.vim
+++ b/syntax/nusmv.vim
@@ -1,0 +1,54 @@
+" Vim syntax file
+" Language:    NuSMV
+" Maintainer:  Wannes Meert <wannes.meert@cs.kuleuven.be>
+" Last Change: 2010 07 18
+" Url:         http://nusmv.irst.itc.it/
+
+if version < 600
+	syntax clear
+elseif exists("b:current_syntax")
+	finish
+endif
+
+" Case sensitive
+syn case match
+
+syn cluster nusmvNotContained contains=nusmvTodo
+
+" Comments
+syn region	nusmvComment		start="--" end="$" contains=nusmvTodo
+syn keyword	nusmvTodo			contained TODO FIXME XXX
+
+" Module
+syn region	nusmvModule			transparent matchgroup=nusmvModuleKeyword start="^\s*MODULE " end="\(MODULE\)\@=" contains=ALLBUT,@nusmvNotContained
+
+" Identifiers
+syn match	nusmvVariable		"\<[a-zA-Z_][a-zA-Z0-9_$#\\-]*\>" contained
+syn match	nusmvValue			"\(TRUE\|FALSE\|\d+\)"
+
+" Keywords
+syn keyword	nusmvSectionKeyword	VAR ASSIGN FAIRNESS TRANS INIT DEFINE CONSTANTS IVAR INVAR SPEC CTLSPEC LTLSPEC PSLSPEC COMPUTE INVARSPEC JUSTICE COMPASSION ISA CONSTRAINT SIMPWFF CTLWFF LTLWFF PSLWFF COMPWFF FROZENVAR
+syn keyword nusmvStorageKeyword	boolean array of integer real word word1 bool
+syn keyword nusmvControlKeyword	process case esac self
+
+" Operators
+syn keyword nusmvOperator		init next EX AX EF AF EG AG E F O G H X Y Z A U S V T BU EBF ABF ABG
+syn match	NusmvOperator		":-" contained
+syn match	NusmvOperator		"<-" contained
+
+
+
+hi def link nusmvComment	Comment
+hi def link nusmvTodo		Todo
+hi def link nusmvVariable	Constant
+hi def link nusmvValue		Number
+
+hi def link nusmvModuleKeyword	Special
+hi def link nusmvSectionKeyword	Special
+hi def link nusmvStorageKeyword	Special
+hi def link nusmvControlKeyword	Special
+
+hi def link nusmvOperator	Operator
+
+let b:current_syntax = "nusvm"
+


### PR DESCRIPTION
Hi, thanks for making this plugin, the syntax highlighting works great for me. I wrote this very simple auto-indent script. It checks for all of the section keywords, and for case/esac statements. Here is an example indentation it produces:

![image](https://user-images.githubusercontent.com/43893492/83352163-01b88a00-a34a-11ea-85a0-3e5251ec7a02.png)

Please let me know if you would like to have it merged.